### PR TITLE
Add option to specify additional fields through annotation

### DIFF
--- a/Annotations/AdditionalFields.php
+++ b/Annotations/AdditionalFields.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Codete\FormGeneratorBundle\Annotations;
+
+/**
+ * @Annotation
+ * @Target("CLASS")
+ *
+ * @author Maciej Malarz <malarzm@gmail.com>
+ */
+class AdditionalFields extends \Doctrine\Common\Annotations\Annotation
+{
+    private $fields = [];
+
+    public function __set($name, $value)
+    {
+        $this->fields[$name] = $value;
+    }
+
+    public function getFields()
+    {
+        return $this->fields;
+    }
+}

--- a/FormConfigurationFactory.php
+++ b/FormConfigurationFactory.php
@@ -5,6 +5,8 @@ namespace Codete\FormGeneratorBundle;
 use Codete\FormGeneratorBundle\Annotations\Display;
 use Codete\FormGeneratorBundle\Annotations\Form;
 use Codete\FormGeneratorBundle\Form\Type\EmbedType;
+use Codete\FormGeneratorBundle\FormField\FormFieldInterface;
+use Codete\FormGeneratorBundle\FormField\PropertyBasedField;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Instantiator\Instantiator;
@@ -83,16 +85,20 @@ class FormConfigurationFactory
                 $properties[] = $ro->getProperty($field);
             }
         }
+        /** @var FormFieldInterface[] $properties */
+        $properties = array_map(function(\ReflectionProperty $property) {
+            return new PropertyBasedField($property, $this->annotationReader);
+        }, $properties);
         foreach ($properties as $property) {
             $propertyIsListed = array_key_exists($property->getName(), $fields);
             if (!empty($fields) && !$propertyIsListed) {
                 continue;
             }
-            $fieldConfiguration = $this->annotationReader->getPropertyAnnotation($property, Display::class);
+            $fieldConfiguration = $property->getConfiguration();
             if ($fieldConfiguration === null && !$propertyIsListed) {
                 continue;
             }
-            $configuration[$property->getName()] = (array)$fieldConfiguration;
+            $configuration[$property->getName()] = (array) $fieldConfiguration;
             if (isset($fields[$property->getName()])) {
                 $configuration[$property->getName()] = array_replace_recursive($configuration[$property->getName()], $fields[$property->getName()]);
             }

--- a/FormField/AdditionalField.php
+++ b/FormField/AdditionalField.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Codete\FormGeneratorBundle\FormField;
+
+/**
+ * Describes a field that is not mapped to a property.
+ *
+ * @author Maciej Malarz <malarzm@gmail.com>
+ */
+class AdditionalField implements FormFieldInterface
+{
+    /**
+     * @var
+     */
+    private $name;
+
+    /**
+     * @var array
+     */
+    private $configuration;
+
+    public function __construct($name, array $configuration)
+    {
+        $this->name = $name;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * By definition the field is not mapped to any property thus it can't have any value.
+     */
+    public function getValue($model)
+    {
+        return null;
+    }
+}

--- a/FormField/FormFieldInterface.php
+++ b/FormField/FormFieldInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Codete\FormGeneratorBundle\FormField;
+
+/**
+ * Represents a field at a time of preparing a form's configuration.
+ *
+ * @author Maciej Malarz <malarzm@gmail.com>
+ */
+interface FormFieldInterface
+{
+    /**
+     * Gets field's configuration.
+     *
+     * @return array|null
+     */
+    public function getConfiguration();
+
+    /**
+     * Gets name of field.
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Gets current value of the field.
+     *
+     * @param object $model
+     * @return mixed
+     */
+    public function getValue($model);
+}

--- a/FormField/PropertyBasedField.php
+++ b/FormField/PropertyBasedField.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Codete\FormGeneratorBundle\FormField;
+
+use Codete\FormGeneratorBundle\Annotations\Display;
+use Doctrine\Common\Annotations\AnnotationReader;
+
+/**
+ * Describes a field that is mapped to a property.
+ *
+ * @author Maciej Malarz <malarzm@gmail.com>
+ */
+class PropertyBasedField implements FormFieldInterface
+{
+    /**
+     * @var \ReflectionProperty
+     */
+    private $property;
+
+    /**
+     * @var AnnotationReader
+     */
+    private $annotationReader;
+
+    public function __construct(\ReflectionProperty $property, AnnotationReader $annotationReader)
+    {
+        $this->property = $property;
+        $this->annotationReader = $annotationReader;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getConfiguration()
+    {
+        $configuration = $this->annotationReader->getPropertyAnnotation($this->property, Display::class);
+        return $configuration ? (array) $configuration : null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getName()
+    {
+        return $this->property->getName();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getValue($model)
+    {
+        return $this->property->getValue($model);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ them as that field's options to the `FormBuilder`. Effectively this allows you t
 separate field's options from options for your configuration modifiers which can be
 a gain on its own.
 
+Adding fields not mapped to a property
+--------------------------------------
+
+**This feature was added in 1.3.0.**
+
+Sometimes you may need to add a field that will not be mapped to a property. An example
+of such use case is adding buttons to the form:
+
+```php
+/**
+ * @Form\AdditionalFields(
+ *     submit = { "type" = "submit", "label" = "Save" }
+ * )
+ */
+class Person
+```
+
+All fields added through `@Form\AdditionalFields` come last in the generated form, unless
+a form view (described below) specifies otherwise. Additionally, such fields are inherited
+from parent classes, and child classes are allowed to override fields' options.
+
 Form Views
 ----------
 

--- a/Tests/FormGeneratorTest.php
+++ b/Tests/FormGeneratorTest.php
@@ -8,6 +8,7 @@ use Codete\FormGeneratorBundle\Tests\FormConfigurationModifier\InactivePersonMod
 use Codete\FormGeneratorBundle\Tests\FormConfigurationModifier\NoPhotoPersonModifier;
 use Codete\FormGeneratorBundle\Tests\Model\Person;
 use Codete\FormGeneratorBundle\Tests\Model\SimpleParent;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\PreloadedExtension;
 
 class FormGeneratorTest extends BaseTest
@@ -250,5 +251,33 @@ class FormGeneratorTest extends BaseTest
         $this->assertEquals('Foo', $form->get('named')->get('name')->getData());
         $this->assertEquals('Bar', $form->get('person')->get('name')->getData());
         $this->assertEquals('Baz', $form->get('person')->get('surname')->getData());
+    }
+
+    public function testAdditionalFieldsAreAddedAndAreLast()
+    {
+        $this->checkForm(new Model\WithAdditionalFields(), ['field', 'submit']);
+    }
+
+    public function testAdditionalFieldCanBeAdjustedByFormAnnotation()
+    {
+        $this->checkForm(new Model\WithAdditionalFields(), ['submit', 'field'], function ($phpunit, $form) {
+            $phpunit->assertSame('Changed', $form->get('submit')->getConfig()->getOption('label'));
+        }, "changeLabelAndOrder");
+    }
+
+    public function testAdditionalFieldsAreInherited()
+    {
+        $this->checkForm(new Model\WithAdditionalFieldsChildInheriting(), ['field', 'submit', 'reset']);
+    }
+
+    public function testAdditionalFieldsCanBePartiallyOverridden()
+    {
+        $this->checkForm(
+            new Model\WithAdditionalFieldsChildOverriding(),
+            ['field', 'submit'],
+            function ($phpunit, $form) {
+                $phpunit->assertSame('Crash Override', $form->get('submit')->getConfig()->getOption('label'));
+            }
+        );
     }
 }

--- a/Tests/Model/WithAdditionalFields.php
+++ b/Tests/Model/WithAdditionalFields.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Codete\FormGeneratorBundle\Tests\Model;
+
+use Codete\FormGeneratorBundle\Annotations as Form;
+
+/**
+ * @Form\Form(
+ *     changeLabelAndOrder = { "submit" = { "label" = "Changed" }, "field" }
+ * )
+ * @Form\AdditionalFields(
+ *     submit = { "type" = "submit", "label" = "Go" }
+ * )
+ */
+class WithAdditionalFields
+{
+    /**
+     * @Form\Display(type="text")
+     */
+    public $field;
+}

--- a/Tests/Model/WithAdditionalFieldsChildInheriting.php
+++ b/Tests/Model/WithAdditionalFieldsChildInheriting.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Codete\FormGeneratorBundle\Tests\Model;
+
+use Codete\FormGeneratorBundle\Annotations as Form;
+
+/**
+ * @Form\AdditionalFields(
+ *     reset = { "type" = "reset", "label" = "Reset" }
+ * )
+ */
+class WithAdditionalFieldsChildInheriting extends WithAdditionalFields
+{
+
+}

--- a/Tests/Model/WithAdditionalFieldsChildOverriding.php
+++ b/Tests/Model/WithAdditionalFieldsChildOverriding.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Codete\FormGeneratorBundle\Tests\Model;
+
+use Codete\FormGeneratorBundle\Annotations as Form;
+
+/**
+ * @Form\AdditionalFields(
+ *     submit = { "label" = "Crash Override" }
+ * )
+ */
+class WithAdditionalFieldsChildOverriding extends WithAdditionalFields
+{
+
+}


### PR DESCRIPTION
Excerpt from readme to illustrate the feature:

Sometimes you may need to add a field that will not be mapped to a property. An example
of such use case is adding buttons to the form:

```php
/**
 * @Form\AdditionalFields(
 *     submit = { "type" = "submit", "label" = "Save" }
 * )
 */
class Person
```

All fields added through `@Form\AdditionalFields` come last in the generated form, unless
a form view (described below) specifies otherwise. Additionally, such fields are inherited
from parent classes, and child classes are allowed to override fields' options.