### PR TITLE
Remove HHVM from testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
- 
+
 env:
   - SYMFONY_VERSION=2.7.*
 
@@ -17,9 +16,6 @@ script:
   - ./vendor/bin/phpunit
 
 matrix:
-  allow_failures:
-    - env: SYMFONY_VERSION=dev-master
-    - php: hhvm
   include:
     - php: 5.6
       env: SYMFONY_VERSION=2.8.*


### PR DESCRIPTION
We're dropping support for HHVM in 2.0